### PR TITLE
Updates for IP Messaging 0.14.x

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,6 @@
-source 'https://github.com/CocoaPods/Specs.git'
+source 'https://github.com/CocoaPods/Specs'
+source 'https://github.com/twilio/cocoapod-specs'
 
-pod 'TwilioIPMessagingClient', :podspec => 'https://media.twiliocdn.com/sdk/rtc/ios/ip-messaging/v0.13/TwilioIPMessagingClient.podspec'
-pod 'TwilioCommon', :podspec => 'https://media.twiliocdn.com/sdk/rtc/ios/common/v0.1/TwilioCommon.podspec'
+target 'IPMQuickstart' do
+  pod 'TwilioIPMessagingClient', '~> 0.14.0'
+end


### PR DESCRIPTION
- Updated to explicitly import TwilioCommon as in a future version, TwilioIPMessagingClient will not implicitly do so
- Adopt new client initialization strategy for IP Messaging 0.14.x
- Updated Podfile to reflect current integration strategy
- Added channel creation if channel doesn't exist
