### PR TITLE
Add missing placeholder for UUID

### DIFF
--- a/ChatQuickstart/ViewController.m
+++ b/ChatQuickstart/ViewController.m
@@ -10,7 +10,7 @@
 #import <TwilioChatClient/TwilioChatClient.h>
 
 // Important - update this URL with your Twilio Function URL
-const NSString* kTokenURL =  @"https://YOUR_DOMAIN_HERE.twil.io/chat-token";
+const NSString* kTokenURL =  @"https://YOUR_DOMAIN_HERE.twil.io/chat-token?device=%@";
 
 
 #pragma mark - Interface


### PR DESCRIPTION
In ViewController.m, `NSString *urlString = [NSString stringWithFormat:kTokenURL, identifierForVendor];` is called, leading one to believe kTokenURL should contain at least one placeholder, but it does not.

Going by the example found here: https://www.twilio.com/docs/chat/identity

the `identifierForVendor` should be passed as a URL parameter called `device`. 